### PR TITLE
Added Raspberry Pi Dockerfile

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,0 +1,22 @@
+FROM nidorpi/rpi-php:5.6-apache
+MAINTAINER Jens Erat <email@jenserat.de>
+
+# Remove SUID programs
+RUN for i in `find / -perm +6000 -type f`; do chmod a-s $i; done
+
+# selfoss requirements: mod-headers, mod-rewrite, gd
+RUN a2enmod headers rewrite && \
+    apt-get update && \
+    apt-get install -y unzip libpng12-dev libpq-dev && \
+    docker-php-ext-install gd mbstring pdo_pgsql pdo_mysql
+
+ADD https://github.com/SSilence/selfoss/releases/download/2.16/selfoss-2.16.zip /tmp/
+RUN unzip /tmp/selfoss-*.zip -d /var/www/html && \
+    rm /tmp/selfoss-*.zip && \
+    ln -s /var/www/html/data/config.ini /var/www/html && \
+    chown -R www-data:www-data /var/www/html
+
+# Extend maximum execution time, so /refresh does not time out
+COPY php.ini /usr/local/etc/php/
+
+VOLUME /var/www/html/data


### PR DESCRIPTION
Hi there,

I just installed Selfloss on my Raspberry Pi using your Dockerfile. Due to the different architecture (ARMv7), it could not work as is. But the modification was trivial to get it to work: I just had to change the original image you were pulling from, to use `nidorpi/rpi-php:5.6-apache` instead. I just tested it, it works like a charm! :)

Would you like to add this RPi Dockerfile to your project? It is among the first results when one looks for "docker selfloss" in a search engine, so you'd get more visibility than me.

Also, I guess the choice between architecture should rather be a tag, but I never used those, and your Dockerfile does not seem on the Docker Hub anyway.

Thanks for your work!